### PR TITLE
fix clang format to 18.1.8

### DIFF
--- a/Debian12/Dockerfile
+++ b/Debian12/Dockerfile
@@ -71,7 +71,7 @@ RUN apt-get update -q -y && apt-get -y --no-install-recommends install build-ess
   mpi4py \
   twine \
   matplotlib \
-  clang-format
+  clang-format==18.1.8
   
   RUN apt-get -y --no-install-recommends install \
   gnuplot-x11 \

--- a/Debian12/Dockerfile
+++ b/Debian12/Dockerfile
@@ -71,7 +71,8 @@ RUN apt-get update -q -y && apt-get -y --no-install-recommends install build-ess
   mpi4py \
   twine \
   matplotlib \
-  clang-format==18.1.8
+  clang-format==18.1.8 \
+  black==24.4.2
   
   RUN apt-get -y --no-install-recommends install \
   gnuplot-x11 \


### PR DESCRIPTION
I would suggest ficing the python package to a specific version number. 
This package is used by the cmake command and in the CI. 

If we don't fix the version the local formatting can get out-of-sync with the formatting in the CI

Also this might not be super useful 
https://github.com/ikarus-project/ikarus-docker-container/blob/15f4bd35db384f2165650a6db0ecb4a88dfcebdc/Debian12/Dockerfile#L41